### PR TITLE
fix(nginx): never cache index.html so clients pick up new bundles

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -9,6 +9,16 @@ server {
         try_files $uri $uri/ /index.html;
     }
 
+    # Never cache the SPA entrypoint. index.html references content-hashed
+    # asset bundles (e.g. index-<hash>.js); if the browser serves a stale
+    # index.html it points at an old bundle that no longer exists on the
+    # origin. Without an explicit Cache-Control, browsers apply heuristic
+    # caching and may skip revalidation. no-store forces a fresh fetch every
+    # load so clients always pick up the current bundle immediately on deploy.
+    location = /index.html {
+        add_header Cache-Control "no-store, must-revalidate";
+    }
+
     location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2)$ {
         expires 1y;
         add_header Cache-Control "public, immutable";


### PR DESCRIPTION
## What

Add an exact-match `location = /index.html` block in `nginx.conf` that sets `Cache-Control: no-store, must-revalidate`, so the SPA entrypoint is never cached by browsers. Hashed assets (`*.js`, `*.css`, etc.) keep their existing `1y immutable` cache.

## Why

`index.html` was served with **no `Cache-Control` header** — only `Last-Modified`/`ETag`. Browsers then apply *heuristic caching* (RFC 7234 §4.2.2) and can serve a stale `index.html` without revalidating. Because `index.html` references content-hashed bundles (`index-<hash>.js`), a stale entrypoint points at an **old bundle** that the new build no longer serves.

This bit us during the **Supabase API key rotation** (compromised `service_role` key): the pre-rotation bundle had the legacy `anon` JWT baked in. After we disabled the legacy keys, clients still loading a cached `index.html` → old bundle kept sending the dead key and hit:

```
Legacy API keys are disabled
```

The origin and the freshly-built bundle (`index-sN9AmqBz.js`) were already correct — the only stale layer was browser-cached `index.html`.

## Fix

```nginx
location = /index.html {
    add_header Cache-Control "no-store, must-revalidate";
}
```

Standard SPA caching strategy: **immutable hashed assets + never-cached HTML entrypoint**. Every future deploy then takes effect immediately for all clients.

## Notes / things to check
- nginx `location` precedence: exact match (`= /index.html`) wins over the prefix `location /` and the asset regex, so the header applies on direct hits.
- SPA fallback: `try_files ... /index.html` and `error_page 404 /index.html` perform internal redirects that re-match `location = /index.html`, so fallback-served HTML is also `no-store`. Worth a sanity check on a preview deploy.
- No app code changes; purely a serving-header fix.

## Verification after deploy
```
curl -sI https://verdad.app/ | grep -i cache-control
# expect: cache-control: no-store, must-revalidate
```

---
Context: follow-up to today's Supabase service_role key rotation incident.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced deployment reliability to ensure users always receive the latest application version, preventing potential issues with outdated content references.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PublicDataWorks/verdad-frontend/pull/255?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->