### PR TITLE
Scanner-safe recovery, magic-link, invite & email-change email flows

### DIFF
--- a/src/components/AuthConfirmPage.tsx
+++ b/src/components/AuthConfirmPage.tsx
@@ -9,9 +9,51 @@ import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle }
 import { LOGIN_PATH, ONBOARDING_PATH, SIGNUP_PATH } from '../constants/routes'
 import supabase from '../lib/supabase'
 
-// Only signup-confirmation tokens belong on this page. Recovery and magic-link
-// emails have their own landing pages (e.g. /reset-password).
-const VALID_EMAIL_OTP_TYPES = new Set(['email', 'signup'])
+interface ConfirmCopy {
+  title: string
+  description: string
+  body: string
+  cta: string
+}
+
+// Per-flow copy for the button-gated confirmation page. Each of these OTP types
+// only establishes a session and redirects, so they share this page.
+// `recovery` is deliberately excluded — it needs a password-set step and has its
+// own page (/reset-password).
+const CONFIRM_COPY: Record<string, ConfirmCopy> = {
+  email: {
+    title: 'Confirm your email',
+    description: 'Continue to finish creating your VERDAD account.',
+    body: 'This final step verifies your email address and opens onboarding.',
+    cta: 'Confirm email'
+  },
+  signup: {
+    title: 'Confirm your email',
+    description: 'Continue to finish creating your VERDAD account.',
+    body: 'This final step verifies your email address and opens onboarding.',
+    cta: 'Confirm email'
+  },
+  magiclink: {
+    title: 'Sign in to VERDAD',
+    description: 'Continue to finish signing in.',
+    body: 'Click below to securely complete your sign-in.',
+    cta: 'Sign in'
+  },
+  invite: {
+    title: 'Accept your invitation',
+    description: 'Continue to set up your VERDAD account.',
+    body: 'Click below to accept your invitation and get started.',
+    cta: 'Accept invitation'
+  },
+  email_change: {
+    title: 'Confirm your email change',
+    description: 'Continue to update your email address.',
+    body: 'Click below to confirm this change to your VERDAD account email.',
+    cta: 'Confirm email change'
+  }
+}
+
+const VALID_EMAIL_OTP_TYPES = new Set(Object.keys(CONFIRM_COPY))
 
 const resolveNextPath = (next: string | null): string => {
   if (!next) return ONBOARDING_PATH
@@ -58,6 +100,7 @@ export default function AuthConfirmPage() {
   const nextPath = useMemo(() => resolveNextPath(searchParams.get('next')), [searchParams])
   const isValidType = type ? VALID_EMAIL_OTP_TYPES.has(type) : false
   const canConfirm = Boolean(tokenHash && isValidType)
+  const copy = isValidType && type ? CONFIRM_COPY[type] : CONFIRM_COPY.email
   // A malformed link (missing/unknown token_hash or type) can never be confirmed,
   // so surface the error state immediately instead of a silently disabled button.
   const displayError = errorMessage ?? (canConfirm ? null : MALFORMED_LINK_MESSAGE)
@@ -97,16 +140,14 @@ export default function AuthConfirmPage() {
             ) : (
               <CheckCircle2 className='mx-auto h-12 w-12 text-blue-600' aria-hidden='true' />
             )}
-            <CardTitle className='text-2xl'>Confirm your email</CardTitle>
-            <CardDescription>Continue to finish creating your VERDAD account.</CardDescription>
+            <CardTitle className='text-2xl'>{copy.title}</CardTitle>
+            <CardDescription>{copy.description}</CardDescription>
           </CardHeader>
           <CardContent className='space-y-4 text-center'>
             {displayError ? (
               <p className='text-sm text-destructive'>{displayError}</p>
             ) : (
-              <p className='text-sm text-muted-foreground'>
-                This final step verifies your email address and opens onboarding.
-              </p>
+              <p className='text-sm text-muted-foreground'>{copy.body}</p>
             )}
           </CardContent>
           <CardFooter className='flex flex-col gap-3'>
@@ -134,7 +175,7 @@ export default function AuthConfirmPage() {
                       Confirming...
                     </>
                   ) : (
-                    'Confirm email'
+                    copy.cta
                   )}
                 </Button>
                 <Button variant='link' type='button' onClick={() => navigate(LOGIN_PATH)}>

--- a/src/components/ResetPassword.tsx
+++ b/src/components/ResetPassword.tsx
@@ -29,6 +29,7 @@ const getResetErrorMessage = (error: AuthError | null): string => {
 export function ResetPassword() {
   const [error, setError] = useState('')
   const [isLoading, setIsLoading] = useState(false)
+  const [isTokenVerified, setIsTokenVerified] = useState(false)
   const [showPassword, setShowPassword] = useState(false)
   const [showConfirmPassword, setShowConfirmPassword] = useState(false)
   const navigate = useNavigate()
@@ -62,10 +63,12 @@ export function ResetPassword() {
 
     const establishLegacySession = async () => {
       try {
-        await supabase.auth.setSession({
+        // setSession resolves with { error } rather than throwing on invalid/expired tokens.
+        const { error: sessionError } = await supabase.auth.setSession({
           access_token: legacyHashParams.access_token,
           refresh_token: legacyHashParams.refresh_token
         })
+        if (sessionError) setError(EXPIRED_LINK_MESSAGE)
       } catch {
         setError(EXPIRED_LINK_MESSAGE)
       }
@@ -82,8 +85,10 @@ export function ResetPassword() {
 
     try {
       // Redeem the one-time recovery token now (scanner-safe), establishing a session
-      // before we change the password.
-      if (tokenHash) {
+      // before we change the password. The token is single-use, so only verify it once:
+      // if updateUser later fails (e.g. weak/duplicate password) and the user retries,
+      // we reuse the session already established instead of re-redeeming a spent token.
+      if (tokenHash && !isTokenVerified) {
         const { error: verifyError } = await supabase.auth.verifyOtp({
           token_hash: tokenHash,
           type: (tokenType ?? 'recovery') as EmailOtpType
@@ -92,6 +97,7 @@ export function ResetPassword() {
           setError(getResetErrorMessage(verifyError))
           return
         }
+        setIsTokenVerified(true)
       }
 
       const { error: updateError } = await supabase.auth.updateUser({

--- a/src/components/ResetPassword.tsx
+++ b/src/components/ResetPassword.tsx
@@ -1,12 +1,13 @@
-import { useState, useEffect } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { useForm, SubmitHandler } from 'react-hook-form'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Button } from '@/components/ui/button'
-import { Eye, EyeOff, Loader2 } from 'lucide-react'
+import { Eye, EyeOff, Loader2, MailWarning } from 'lucide-react'
+import type { AuthError, EmailOtpType } from '@supabase/supabase-js'
 import supabase from '../lib/supabase'
-import { useNavigate } from 'react-router-dom'
+import { useNavigate, useSearchParams } from 'react-router-dom'
 import PublicHeader from './PublicHeader'
 
 type FormData = {
@@ -14,13 +15,40 @@ type FormData = {
   confirmPassword: string
 }
 
+const EXPIRED_LINK_MESSAGE =
+  'This password reset link is invalid or has expired. Please request a new reset email and try again.'
+
+const getResetErrorMessage = (error: AuthError | null): string => {
+  if (!error) return EXPIRED_LINK_MESSAGE
+  // Expired, already-consumed (e.g. by an email link scanner), or malformed tokens
+  // surface as 403s with an "expired or is invalid" message.
+  if (error.status === 403 || /expired|invalid/i.test(error.message)) return EXPIRED_LINK_MESSAGE
+  return error.message
+}
+
 export function ResetPassword() {
   const [error, setError] = useState('')
   const [isLoading, setIsLoading] = useState(false)
+  const [showPassword, setShowPassword] = useState(false)
+  const [showConfirmPassword, setShowConfirmPassword] = useState(false)
   const navigate = useNavigate()
-  const hash = location.hash.substring(1)
-  const searchParams = new URLSearchParams(hash)
-  const params = Object.fromEntries(searchParams)
+  const [searchParams] = useSearchParams()
+
+  // Scanner-safe recovery flow: the email links here with a one-time token in the
+  // query string. We do NOT redeem it on load — only when the user submits a new
+  // password, so email security scanners that merely fetch the page can't consume it.
+  const tokenHash = searchParams.get('token_hash')
+  const tokenType = searchParams.get('type')
+
+  // Legacy implicit flow: older in-flight reset emails redirect here with session
+  // tokens in the URL hash. Keep supporting them until they age out.
+  const legacyHashParams = useMemo(() => {
+    const hash = window.location.hash.startsWith('#') ? window.location.hash.substring(1) : window.location.hash
+    return Object.fromEntries(new URLSearchParams(hash))
+  }, [])
+
+  const hasLegacyTokens = Boolean(legacyHashParams.access_token && legacyHashParams.refresh_token)
+  const hasResetCredential = Boolean(tokenHash) || hasLegacyTokens
 
   const {
     register,
@@ -30,22 +58,21 @@ export function ResetPassword() {
   } = useForm<FormData>()
 
   useEffect(() => {
-    const updateSession = async () => {
+    if (!hasLegacyTokens) return
+
+    const establishLegacySession = async () => {
       try {
-        if (params.access_token && params.refresh_token) {
-          const response = await supabase.auth.setSession({
-            access_token: params.access_token,
-            refresh_token: params.refresh_token
-          })
-        }
-      } catch (error) {
-        setError('Invalid or expired reset link')
-        setTimeout(() => navigate('/login'), 3000)
+        await supabase.auth.setSession({
+          access_token: legacyHashParams.access_token,
+          refresh_token: legacyHashParams.refresh_token
+        })
+      } catch {
+        setError(EXPIRED_LINK_MESSAGE)
       }
     }
 
-    updateSession()
-  }, [params.access_token, params.refresh_token, navigate])
+    void establishLegacySession()
+  }, [hasLegacyTokens, legacyHashParams.access_token, legacyHashParams.refresh_token])
 
   const password = watch('password')
 
@@ -54,29 +81,67 @@ export function ResetPassword() {
     setIsLoading(true)
 
     try {
-      const { error } = await supabase.auth.updateUser({
+      // Redeem the one-time recovery token now (scanner-safe), establishing a session
+      // before we change the password.
+      if (tokenHash) {
+        const { error: verifyError } = await supabase.auth.verifyOtp({
+          token_hash: tokenHash,
+          type: (tokenType ?? 'recovery') as EmailOtpType
+        })
+        if (verifyError) {
+          setError(getResetErrorMessage(verifyError))
+          return
+        }
+      }
+
+      const { error: updateError } = await supabase.auth.updateUser({
         password: data.password
       })
-
-      if (error) {
-        throw error
+      if (updateError) {
+        setError(getResetErrorMessage(updateError))
+        return
       }
-      // Show success message or redirect
+
       navigate('/login', {
         state: {
           message: 'Password successfully reset. Please login with your new password.'
         }
       })
     } catch (err) {
-      console.error('Error:', err)
       setError(err instanceof Error ? err.message : 'An error occurred while resetting the password.')
     } finally {
       setIsLoading(false)
     }
   }
 
-  const [showPassword, setShowPassword] = useState(false)
-  const [showConfirmPassword, setShowConfirmPassword] = useState(false)
+  if (!hasResetCredential) {
+    return (
+      <div className='min-h-screen'>
+        <PublicHeader />
+        <div className='mx-auto px-4 py-16'>
+          <Card className='mx-auto max-w-lg rounded-xl p-8'>
+            <CardHeader className='space-y-3 text-center'>
+              <MailWarning className='mx-auto h-12 w-12 text-destructive' aria-hidden='true' />
+              <CardTitle className='text-3xl font-bold tracking-tight text-gray-900'>Reset link required</CardTitle>
+              <p className='text-gray-500'>
+                Open the most recent password reset email and use its link, or request a new one.
+              </p>
+            </CardHeader>
+            <CardContent className='mt-8 flex flex-col gap-3'>
+              <Button
+                className='w-full rounded-lg bg-blue-600 px-4 py-3 text-white hover:bg-blue-700'
+                onClick={() => navigate('/forget-password')}>
+                Request a new reset link
+              </Button>
+              <Button variant='link' type='button' onClick={() => navigate('/login')}>
+                Back to login
+              </Button>
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    )
+  }
 
   return (
     <div className='min-h-screen'>


### PR DESCRIPTION
## Problem

Follow-up to #256. That PR fixed the **signup** confirmation flow against email security scanners (Microsoft Safe Links) that consume single-use `{{ .ConfirmationURL }}` links — which hit Supabase's `/auth/v1/verify` on first GET — before the user clicks. Four other email templates still carry the same scanner-consumable links:

| Template | Frontend status | Impact |
|---|---|---|
| **recovery** (password reset) | **Active** (`ForgetPassword` → `resetPasswordForEmail`) | Password resets fail the same way signups did |
| magic_link | Dormant (no UI triggers `signInWithOtp`) | Hardened for future/manual use |
| invite | Admin-initiated (`inviteUserByEmail`) | Invited users hit expired-link errors |
| email_change | Dormant (no email-change UI) | Hardened; `secure_email_change` sends links to **both** addresses |

## Fix

Same button-gated pattern as #256 — the one-time token is redeemed only on an explicit user action, which scanners don't perform.

- **`AuthConfirmPage` generalized** to handle `magiclink`, `invite`, and `email_change` (in addition to `email`/`signup`), with type-aware copy (title/description/CTA). `verifyOtp` still fires only on button click. **`recovery` is deliberately excluded** — it needs a password-set step, not a redirect.
- **`ResetPassword` upgraded** for the recovery flow: reads `?token_hash=&type=recovery`, redeems it via `verifyOtp` **on form submit** (the human gate), then `updateUser({ password })`. The legacy URL-hash (`access_token`/`refresh_token`) path is kept for in-flight old emails, and a clear "reset link required" state shows when no credential is present.

## Coupling (deploy order)

After this merges and deploys, the four Supabase templates will be pointed at the new routes (via Management API, as in #256):

- recovery → `https://verdad.app/reset-password?token_hash={{ .TokenHash }}&type=recovery`
- magic_link / invite / email_change → `https://verdad.app/auth/confirm?token_hash={{ .TokenHash }}&type=<type>&next={{ .RedirectTo }}`

(`{{ .SiteURL }}` is **not** used — VERDAD's `site_url` includes a `/onboarding` path, so template links are hardcoded to `https://verdad.app`.) Routes ship **before** templates so emails never point at a missing page.

## Verification

- `npm run build` passes (the CI/deploy gate); `AuthConfirmPage` lints clean. `ResetPassword` carries only pre-existing repo lint patterns (repo-wide lint is not a gate; ~1100 pre-existing failures, count unchanged).
- End-to-end recovery test (real token from `auth.one_time_tokens`, scanner GET/HEAD simulation, then form submit) to be run against production after merge and posted here.

## Notes

- **email_change** with `secure_email_change` requires confirming **both** old- and new-address emails; each link click verifies its own token via the shared template. Functional but the user sees a success state per click.
- **invite**: verifying establishes a session and lands on onboarding; invited users have no password (same as Google signups) and can set one later via password reset. Minimal change for a rare admin flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)